### PR TITLE
PR-review: changes for Node.js and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ products:
 - entra-id
 urlFragment: azure-functions-completion-openai-dotnet
 languages:
-- JavaScript
-- bicep
 - azdeveloper
+- bicep
+- nodejs
+- javascript
 ---
 -->
 
@@ -34,11 +35,6 @@ You can learn more about the OpenAI trigger and bindings extension in the [GitHu
 ## Prepare your local environment
 
 ### Create Azure OpenAI resource for local and cloud dev-test
-
-Run the following command to download the project code
-```bash
-azd init -t https://github.com/Azure-Samples/azure-functions-completion-openai-node
-```
 
 Enable scripts to create local settings file after deployment
 Mac/Linux:
@@ -100,14 +96,6 @@ Run this command to provision the function app, with any required Azure resource
 ```shell
 azd up
 ```
-
-You're prompted to supply these required deployment parameters:
-
-| Parameter | Description |
-| ---- | ---- |
-| _Environment name_ | An environment that's used to maintain a unique deployment context for your app. You won't be prompted if you created the local project using `azd init`.|
-| _Azure subscription_ | Subscription in which your resources are created.|
-| _Azure location_ | Azure region in which to create the resource group that contains the new Azure resources. Only regions that currently support the Flex Consumption plan are shown.|
 
 After publish completes successfully, `azd` provides you with the URL endpoints of your new functions, but without the function key values required to access the endpoints. To learn how to obtain these same endpoints along with the required function keys, see [Invoke the function on Azure](https://learn.microsoft.com/azure/azure-functions/create-first-function-azure-developer-cli?pivots=programming-language-dotnet#invoke-the-function-on-azure) in the companion article [Quickstart: Create and deploy functions to Azure Functions using the Azure Developer CLI](https://learn.microsoft.com/azure/azure-functions/create-first-function-azure-developer-cli?pivots=programming-language-dotnet).
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
-name: azure-functions-completion-openai-dotnet
+name: azure-functions-completion-openai-node
 metadata:
-  template:  azure-functions-completion-openai-dotnet@1.0.0
+  template:  azure-functions-completion-openai-node@1.0.0
 services:
   api:
     project: ./src

--- a/infra/scripts/createlocalsettings.ps1
+++ b/infra/scripts/createlocalsettings.ps1
@@ -15,7 +15,7 @@ if (-not (Test-Path ".\src\local.settings.json")) {
         "IsEncrypted" = "false";
         "Values" = @{
             "AzureWebJobsStorage" = "UseDevelopmentStorage=true";
-            "FUNCTIONS_WORKER_RUNTIME" = "dotnet-isolated";
+            "FUNCTIONS_WORKER_RUNTIME" = "node";
             "AZURE_OPENAI_ENDPOINT" = "$AZURE_OPENAI_ENDPOINT";
             "CHAT_MODEL_DEPLOYMENT_NAME" = "completion";
         }

--- a/infra/scripts/createlocalsettings.sh
+++ b/infra/scripts/createlocalsettings.sh
@@ -21,7 +21,7 @@ if [ ! -f "./src/local.settings.json" ]; then
     "IsEncrypted": "false",
     "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+        "FUNCTIONS_WORKER_RUNTIME": "node",
         "AZURE_OPENAI_ENDPOINT": "$AZURE_OPENAI_ENDPOINT",
         "CHAT_MODEL_DEPLOYMENT_NAME": "completion"
     }


### PR DESCRIPTION
## Purpose
This is a code review as a PR for the dotnet to node conversion.

There are a few changes to make this work well for Node/javascript:
- changes to `/infra/scripts/` so local.settings.json loads and runs in node
- `readme.md` metadata for node
- template naming for node that is distinct from dotnet-variant in `azure.yaml`

Also I propose simplifying readme with things like:
- no need to tell someone to azd init --template.  They are already in github so know to clone, vs. make a copy of a clone.  alternatively I'd add a GitHub Codespaces button like we do in HTTP quickstarts if you want an instant approach.  Note once this is in AZD gallery, the azd init --template command will be shown there.
- a few other simplifications to take user from clone -> restore -> run -> up


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Use the readme