### PR TITLE
Configure for remote build: create .funcignore and update azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,7 @@ services:
     project: ./src
     language: js
     host: function
+    remoteBuild: true
 hooks:
   postprovision:
     windows:

--- a/src/.funcignore
+++ b/src/.funcignore
@@ -1,0 +1,9 @@
+*.js.map
+.git*
+.vscode
+__azurite_db*__.json
+__blobstorage__
+__queuestorage__
+local.settings.json
+test
+node_modules


### PR DESCRIPTION
This PR configures the project for remote build when deploying with `azd`.

## Changes

### `src/.funcignore`
- Created new `.funcignore` file with standard ignores and `node_modules` excluded

### `azure.yaml`
- Added `remoteBuild: true` to the service configuration

## Why

When deploying with `azd`, remote build is used. The `.funcignore` should exclude `node_modules` so that dependencies are installed on the server during deployment rather than being uploaded from the local machine. This avoids issues with platform-specific native binaries and reduces deployment package size.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.